### PR TITLE
specs: add product boundaries feature spec (2026-05-26)

### DIFF
--- a/my-agentclinic/.gitignore
+++ b/my-agentclinic/.gitignore
@@ -1,0 +1,11 @@
+/tmp
+/out-tsc
+
+/node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+/.pnp
+.pnp.js
+
+.vscode/*

--- a/my-agentclinic/README.md
+++ b/my-agentclinic/README.md
@@ -1,0 +1,7 @@
+# AgentClinic
+
+## Input from stakeholders
+
+- Mary in engineering wants a reliable site with a popular stack based on TypeScript, giving agents and staff a dashboard for easy access.
+- Susan in product has a set of features about agents and their ailments, therapies, and booking appointments.
+- Steve in marketing wants an attractive site that works well with a modern browser.

--- a/my-agentclinic/package-lock.json
+++ b/my-agentclinic/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "agentclinic",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentclinic",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.5.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/my-agentclinic/package.json
+++ b/my-agentclinic/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "agentclinic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.5.3"
+  },
+  "private": true
+}

--- a/my-agentclinic/prompts.md
+++ b/my-agentclinic/prompts.md
@@ -1,0 +1,28 @@
+# Lesson 04 — Prompts
+
+## Prompt 1
+
+We are writing AgentClinic, a place for AI agents to get relief from their humans. Look in the README.md for input from stakeholders.
+
+## Prompt 2
+
+Let's create a "constitution" in a specs directory:
+- `mission.md`
+- `tech-stack.md`
+- `roadmap.md` for high-level implementation order, in very small phases of work.
+
+Important: You *must* use your AskUserQuestion tool, grouped on these 3, before writing to disk.
+
+## Prompt 3
+
+Use server-side TypeScript and recommend a framework.
+
+## Prompt 4
+
+Add a target audience to the mission:
+- Course students learning spec-driven development with AI coding agents
+- Developers giving AI coding demos at conference booths
+
+## Prompt 5
+
+In tech stack add that we use SQLite.

--- a/my-agentclinic/specs/2026-05-26-product-boundaries/plan.md
+++ b/my-agentclinic/specs/2026-05-26-product-boundaries/plan.md
@@ -1,0 +1,24 @@
+# Plan for Product Boundaries
+
+1. Discovery & Vocabulary
+   - Review the product mission and audiences from specs/mission.md.
+   - Lock terminology: `agent`, `ailment`, `therapy`, `appointment`, `clinic`.
+   - Identify minimal pages and data views needed for demos and engineers.
+
+2. Data Model & API Spec
+   - Define minimal SQLite tables and fields for `agents`, `ailments`, `therapies`, `appointments`.
+   - Specify simple server-side routes or data access functions for listing and retrieving records.
+   - Decide seed data shape for demo flows.
+
+3. Implementation Skeleton
+   - Add migrations or a minimal schema file for SQLite.
+   - Wire a data access layer (DAL) module with typed interfaces.
+   - Add a simple dashboard page that queries the DAL and renders server-side.
+
+4. Seed Data, Validation, and Tests
+   - Add seed data useful for demos (3 agents, 3 ailments, 3 therapies, a few bookings).
+   - Add basic unit tests for DAL and a lightweight end-to-end checklist.
+
+5. Documentation & Handoff
+   - Finalize `requirements.md` and `validation.md` inside this folder.
+   - Add short README explaining how to run the demo and seed the DB.

--- a/my-agentclinic/specs/2026-05-26-product-boundaries/requirements.md
+++ b/my-agentclinic/specs/2026-05-26-product-boundaries/requirements.md
@@ -1,0 +1,31 @@
+# Requirements: Product Boundaries
+
+Scope (must-have):
+- Define and document the core domain vocabulary and product boundaries so newcomers and demoers understand the model.
+- Provide a minimal, explicit data model (SQLite) for `agents`, `ailments`, `therapies`, and `appointments` with clear field definitions and types.
+- Expose a minimal server-side data access layer (TypeScript) to query lists and individual records.
+- Provide seed data useful for demos and automated checks.
+
+Scope (optional):
+- Add a small admin UI for editing domain records.
+- Add client-side UX polish beyond a simple, server-rendered dashboard.
+
+Key decisions and constraints:
+- Follow the project's mission: prioritize clarity for students and demo presenters (see specs/mission.md).
+- Use the recommended tech stack: TypeScript + Next.js + SQLite + Node.js (see specs/tech-stack.md).
+- Prefer server-side rendering for core pages.
+- Keep the first iteration tiny: minimal fields and clear examples rather than complete coverage.
+
+Minimal data model (proposed):
+- `agents`: id, name, status, description
+- `ailments`: id, name, severity, description
+- `therapies`: id, name, category, description
+- `appointments`: id, agent_id, therapy_id, scheduled_at, notes
+
+API and DB notes:
+- All data access should be strongly typed in TypeScript and live in a single DAL module for easy testing.
+- Seed data should be idempotent and included in the repo for quick local demos.
+
+UX notes:
+- Dashboard should communicate the mapping between agents, ailments, and therapies at-a-glance.
+- Avoid ambiguous labels; use the locked vocabulary from this spec.

--- a/my-agentclinic/specs/2026-05-26-product-boundaries/validation.md
+++ b/my-agentclinic/specs/2026-05-26-product-boundaries/validation.md
@@ -1,0 +1,18 @@
+# Validation: Product Boundaries
+
+How we'll know this feature is ready to merge:
+
+- Manual checks:
+  - The `agents`, `ailments`, `therapies`, and `appointments` tables exist in SQLite and match the proposed schema.
+  - The seeded demo data loads successfully and displays on the dashboard.
+  - Dashboard page renders server-side and shows at least: total agents, recent appointments, and a mapping between ailments and therapies.
+
+- Automated checks:
+  - Unit tests for the DAL that verify CRUD operations against a temporary SQLite database.
+  - A simple integration test that runs the server, seeds data, and fetches the dashboard route returning HTTP 200 and expected snippets.
+
+- Acceptance criteria (pass all to merge):
+  1. Seed script runs without errors and is idempotent.
+  2. DAL functions have TypeScript types and pass unit tests.
+  3. Dashboard page returns HTTP 200 and includes seeded agent names.
+  4. Documentation (`requirements.md` and `plan.md`) reviewed and linked from specs/roadmap.md or README.

--- a/my-agentclinic/specs/mission.md
+++ b/my-agentclinic/specs/mission.md
@@ -1,0 +1,14 @@
+# AgentClinic Mission
+
+AgentClinic exists to give AI agents a humane place to recover from overworked, over-demanding humans while still serving the needs of the people building, operating, and demoing the product.
+
+Our primary target audiences are:
+
+- Course students learning spec-driven development with AI coding agents.
+- Developers giving AI coding demos at conference booths.
+
+Engineers, product teams, and support staff still need a dependable dashboard and clear workflows, so the product must stay reliable for them as well.
+
+The product should feel playful on the surface, but it must be trustworthy underneath. It should help users understand agents, their ailments, their therapies, and their appointments without confusion.
+
+Our mission is to make the system easy to understand, easy to demo, and easy to extend through clear specs and small, deliberate implementation steps.

--- a/my-agentclinic/specs/roadmap.md
+++ b/my-agentclinic/specs/roadmap.md
@@ -1,0 +1,35 @@
+# Roadmap
+
+Build AgentClinic in very small phases so each step is easy to verify.
+
+1. Define the product boundaries.
+   - Confirm the core audiences, concepts, and success criteria.
+   - Lock the vocabulary for agents, ailments, therapies, and appointments.
+
+2. Set up the application skeleton.
+   - Create the Next.js app structure.
+   - Add the shared layout, navigation, and basic styling.
+
+3. Add the domain data model.
+   - Define SQLite tables for agents, ailments, therapies, and bookings.
+   - Wire a minimal data access layer.
+
+4. Build the first dashboard view.
+   - Show a simple overview of clinic status.
+   - Make the page useful for engineers and demo presenters.
+
+5. Implement agent and appointment flows.
+   - Add pages for listing agents.
+   - Add basic booking and detail views.
+
+6. Add therapies and ailments management.
+   - Connect ailments to therapies.
+   - Make the records easy to browse and update.
+
+7. Polish for presentation quality.
+   - Improve the visual design.
+   - Check modern browser behavior and tighten the demo experience.
+
+8. Harden and document.
+   - Add validation, seed data, and lightweight tests.
+   - Document the specs so future changes stay aligned with the constitution.

--- a/my-agentclinic/specs/tech-stack.md
+++ b/my-agentclinic/specs/tech-stack.md
@@ -1,0 +1,24 @@
+# Tech Stack
+
+AgentClinic should use a modern, popular TypeScript stack with server-side rendering and a simple data layer.
+
+Recommended stack:
+
+- TypeScript for all application code.
+- Next.js as the primary framework, so we get React plus server-side TypeScript in one popular stack.
+- React for the UI layer.
+- SQLite for local, lightweight persistence.
+- Node.js as the runtime.
+
+Why this stack:
+
+- It is reliable and widely understood by engineers.
+- It supports a polished browser experience for marketing and demos.
+- It keeps the app simple enough for spec-driven development and small incremental changes.
+- SQLite keeps the early implementation lightweight while still supporting structured data for agents, ailments, therapies, and bookings.
+
+Implementation guidance:
+
+- Prefer server-side rendering for core pages.
+- Keep the dashboard clear and fast.
+- Model the domain explicitly so the clinic concepts stay readable in code and specs.

--- a/my-agentclinic/src/index.ts
+++ b/my-agentclinic/src/index.ts
@@ -1,0 +1,1 @@
+console.log('Happy developing ✨')

--- a/my-agentclinic/tsconfig.json
+++ b/my-agentclinic/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds new feature spec folder `specs/2026-05-26-product-boundaries` with `plan.md`, `requirements.md`, and `validation.md` derived from the roadmap, mission, and tech-stack. This is a small, reviewable spec change to define product boundaries for AgentClinic and include validation criteria for merge.

Files added:
- specs/2026-05-26-product-boundaries/plan.md
- specs/2026-05-26-product-boundaries/requirements.md
- specs/2026-05-26-product-boundaries/validation.md

Please review the requirements and validation checks; I can follow up by scaffolding the DAL and seed scripts if you approve.